### PR TITLE
add openssl-dev and libffi-dev to the image

### DIFF
--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine3.11
 
-RUN apk add --no-cache bash make
+RUN apk add --no-cache bash make openssl-dev libffi-dev
 RUN pip install --upgrade pip setuptools
 RUN pip install --upgrade pipenv
 

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine3.11
 
-RUN apk add --no-cache bash make
+RUN apk add --no-cache bash make openssl-dev libffi-dev
 RUN pip install --upgrade pip setuptools
 RUN pip install --upgrade pipenv
 


### PR DESCRIPTION
required to install `cffi` and `cryptography` python packages