### PR TITLE
fix poetry PATH addition

### DIFF
--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -7,6 +7,6 @@ RUN pip install --upgrade pipenv
 # setup poetry
 ENV POETRY_VERSION "1.0.10"
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-ENV PATH "$PATH:root/.poetry/bin"
+ENV PATH "$PATH:/root/.poetry/bin"
 
 CMD ["/bin/bash"]

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -7,6 +7,6 @@ RUN pip install --upgrade pipenv
 # setup poetry
 ENV POETRY_VERSION "1.0.10"
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-ENV PATH "$PATH:root/.poetry/bin"
+ENV PATH "$PATH:/root/.poetry/bin"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
The missing `/` caused poetry to only be found if not changing directories. If the user changed directories for any reason, poetry would no longer be found.